### PR TITLE
feat: shuffle bookings and optimize memory

### DIFF
--- a/packages/simulator/index.js
+++ b/packages/simulator/index.js
@@ -44,8 +44,9 @@ const engine = {
           take(Math.ceil(kommun.packageVolumes.B2C / WORKING_DAYS)), // how many bookings do we want?
         )
 
-        // TODO: Could we do this without converting to an array?
+        // TODO: Could we do this without converting to an array? Yes. By using fs stream and write json per line
         bookings.pipe(
+          map(({id, pickup, destination}) => ({id, pickup, destination})), // remove all unneccessary data such as car and eventemitter etc
           toArray(),
         ).subscribe(arr => {
           fs.writeFileSync(file, JSON.stringify(arr))

--- a/packages/simulator/lib/booking.js
+++ b/packages/simulator/lib/booking.js
@@ -1,8 +1,11 @@
 const EventEmitter = require('events')
+const { virtualTime } = require('../lib/virtualTime')
+const { safeId } = require('./id')
 
 class Booking extends EventEmitter {
   constructor(booking) {
     super()
+    this.id = safeId()
     this.status = 'New'
     Object.assign(this, booking)
     this.position = this.pickup?.position
@@ -10,7 +13,7 @@ class Booking extends EventEmitter {
   }
 
   queued(car) {
-    this.queuedDateTime = new Date()
+    this.queuedDateTime = virtualTime.time()
     this.status = 'Queued'
     this.car = car
     this.emit('queued', this)
@@ -18,7 +21,7 @@ class Booking extends EventEmitter {
   }
 
   assigned(car) {
-    this.assignedDateTime = new Date()
+    this.assignedDateTime = virtualTime.time()
     this.car = car
     this.status = 'Assigned'
     this.emit('assigned', this)
@@ -30,7 +33,7 @@ class Booking extends EventEmitter {
     this.emit('moved', this)
   }
 
-  pickedUp(position, date) {
+  pickedUp(position, date = virtualTime.time()) {
     this.pickupDateTime = date
     this.pickupPosition = position
     this.status = 'Picked up'
@@ -38,9 +41,10 @@ class Booking extends EventEmitter {
     console.log(`*** booking ${this.id}: ${this.status}`)
   }
 
-  delivered(position, date) {
+  delivered(position, date = virtualTime.time()) {
     this.deliveredDateTime = date
     this.deliveredPosition = position
+    this.deliveryTime = (date - (this.assignedDateTime || this.queuedDateTime)) / 1000
     this.status = 'Delivered'
     this.emit('delivered', this)
     // console.log(`*** booking ${this.id}: ${this.status}`)

--- a/packages/simulator/lib/car.js
+++ b/packages/simulator/lib/car.js
@@ -88,12 +88,12 @@ class Car extends EventEmitter {
       // see if we have more packages to pickup from this position
       while (this.queue.length && haversine(this.position, this.queue[0].pickup.position) < 100) {
         const booking = this.queue.shift()
-        booking.pickedUp(this.position, this.time())
+        booking.pickedUp(this.position)
         this.cargo.push(booking)
         this.emit('cargo', this)
       }
       if (this.booking && this.booking.destination) {
-        this.booking.pickedUp(this.position, this.time())
+        this.booking.pickedUp(this.position)
         this.status = 'Delivery'
 
         // should we first pickup more bookings before going to the destination?
@@ -110,7 +110,7 @@ class Car extends EventEmitter {
     //finfo(`Dropoff ${this.booking.id}`)
     if (this.booking) {
       this.busy = false
-      this.booking.delivered(this.position, this.time())
+      this.booking.delivered(this.position)
       this.delivered.push(this.booking)
       this.emit('busy', this)
       this.emit('dropoff', this)
@@ -159,7 +159,7 @@ class Car extends EventEmitter {
       this.booking.moved(this.position)
     }
 
-    if (this.ema < 1000 && this.speed < 10) {
+    if (!position.next || this.ema < 1000 && this.speed < 10) {
       this.emit('stopped', this)
       this.simulate(false)
       if (this.booking) {

--- a/packages/simulator/simulator/bookings.js
+++ b/packages/simulator/simulator/bookings.js
@@ -68,8 +68,8 @@ function generateBookingsInKommun(kommun) {
       first(area => isInsideCoordinates(point.position, area.geometry.coordinates), false),
       map(commercialArea => ({...point, isCommercial: !!commercialArea } ))
     )),*/
-    //toArray(), // convert to array to be able to sort the addresses
-    //mergeMap((a) => from(a.sort((p) => Math.random() - 0.5 - (p.isCommercial ? 2 : 0)))),
+    toArray(), // convert to array to be able to sort the addresses
+    mergeMap((a) => from(a.sort((p) => Math.random() - 0.5))),
     // ratelimit(5, 1000),
     mergeMap(({ nearestOmbud, position }) => {
       return pelias
@@ -90,7 +90,6 @@ function generateBookingsInKommun(kommun) {
             //                introducera klass Fastighet som en ström som emittar bokningar
           }
           return new Booking({
-            id: id++,
             pickup: nearestOmbud, // { position: convertPosition(kommun.pickupPositions[Math.floor(Math.random() * kommun.pickupPositions.length)]) },
             isCommercial: address.layer === 'venue',
             destination: address,

--- a/packages/simulator/web/routes.js
+++ b/packages/simulator/web/routes.js
@@ -73,11 +73,11 @@ function register(io) {
           pickup: { position: pickup }, 
           destination: { position: destination, name }, 
           id, status, isCommercial, 
-          pickupDateTime, deliveredDateTime, car 
+          deliveryTime, car 
         }) => ({ 
           id, pickup, destination,
           name, status, isCommercial, 
-          pickupDateTime, deliveredDateTime, 
+          deliveryTime, 
           carId: car?.id 
         })),
         //distinct(booking => booking.id),
@@ -99,13 +99,13 @@ function register(io) {
 
             const averageDeliveryTime = bookings.pipe(
               mergeMap(booking => fromEvent(booking, 'delivered')),
-              scan(({ total, deliveryTimeTotal }, { pickupDateTime, deliveredDateTime }) => ({
+              scan(({ total, deliveryTimeTotal }, { deliveryTime }) => ({
                 total: total + 1,
-                deliveryTimeTotal: deliveryTimeTotal + (new Date(deliveredDateTime) - new Date(pickupDateTime))
+                deliveryTimeTotal: deliveryTimeTotal + deliveryTime
               }),
                 { total: 0, deliveryTimeTotal: 0 }),
               startWith({ total: 0, deliveryTimeTotal: 0 }),
-              map(({ total, deliveryTimeTotal }) => ({ totalDelivered: total, averageDeliveryTime: deliveryTimeTotal / total }))
+              map(({ total, deliveryTimeTotal }) => ({ totalDelivered: total, averageDeliveryTime: (deliveryTimeTotal / total) / 60 / 60 }))
             )
 
             const averageUtilization = cars.pipe(

--- a/packages/visualisation/src/App.js
+++ b/packages/visualisation/src/App.js
@@ -9,6 +9,7 @@ import Loading from './components/Loading/index.js'
 const App = () => {
   const [activeCar, setActiveCar] = useState(null)
   const [reset, setReset] = useState(false)
+  const [speed, setSpeed] = React.useState(60)
 
   useSocket('reset', () => {
     console.log('received reset')
@@ -16,6 +17,7 @@ const App = () => {
     setCars([])
     setKommuner([])
     setPostombud([])
+    socket.emit('speed', speed) // reset speed on server
   })
 
   const [cars, setCars] = React.useState([])
@@ -37,8 +39,8 @@ const App = () => {
   const [bookings, setBookings] = React.useState([])
   useSocket('bookings', (newBookings) => {
     setBookings((bookings) => [
-      ...bookings,
-      ...newBookings.map(({ name, id, pickup, destination, status, isCommercial, pickupDateTime, deliveredDateTime, carId }) => ({
+      ...bookings.filter(booking => !newBookings.some(b => b.id === booking.id)),
+      ...newBookings.map(({ name, id, pickup, destination, status, isCommercial, deliveryTime, carId }) => ({
         id,
         address: name,
         status,
@@ -46,9 +48,7 @@ const App = () => {
         pickup: [pickup.lon, pickup.lat],
         destination: [destination.lon, destination.lat],
         carId,
-        deliveredDateTime,
-        pickupDateTime,
-        deliveryTime: new Date(deliveredDateTime) - new Date(pickupDateTime)
+        deliveryTime
       })),
     ])
   })
@@ -84,7 +84,7 @@ const App = () => {
 
   const onSpeedChange = (value) => {
     socket.emit('speed', value)
-    console.log('speed change, ', value)
+    setSpeed(value)
   }
 
   const Reset = () => {

--- a/packages/visualisation/src/components/HoverInfoBox/index.js
+++ b/packages/visualisation/src/components/HoverInfoBox/index.js
@@ -58,7 +58,7 @@ const HoverInfoBox = ({ data }) => {
         <Wrapper left={data.x} top={data.y}>
             <Paragraph>{data.title}</Paragraph>
             <Paragraph>{data.subTitle}</Paragraph>
-            {data.deliveryTime ? <Paragraph>Leveranstid: {Math.ceil(10 * data.deliveryTime / 60 / 60) / 10} h</Paragraph> : null}
+            {data.deliveryTime ? <Paragraph>Leveranstid: {Math.ceil(10 * data.deliveryTime) / 10} h</Paragraph> : null}
         </Wrapper>
       )}
     </>

--- a/packages/visualisation/src/components/KommunStatisticsBox/index.js
+++ b/packages/visualisation/src/components/KommunStatisticsBox/index.js
@@ -27,7 +27,7 @@ const KommunStatisticsBox = ({ name, totalCars, totalBookings, totalCapacity, av
                 <Paragraph>Just nu kör {totalCars} lastbilar i {name}</Paragraph>
                 <Paragraph>Total kapacitet: {totalCapacity} paket</Paragraph>
                 <Paragraph>Levererade: {totalDelivered} paket</Paragraph>
-                <Paragraph>Medel leveranstid: {Math.ceil(2 * averageDeliveryTime / 60 / 60) / 2}h</Paragraph>
+                <Paragraph>Medel leveranstid: {Math.ceil(2 * averageDeliveryTime) / 2}h</Paragraph>
 
                 {/* <Paragraph>Total cargo: {totalCargo}</Paragraph> */}
                 <Paragraph>Antal bokningar: {totalBookings} paket</Paragraph>


### PR DESCRIPTION
Now we have more evenly distributed bookings. Also the bookings that we already have shown on the map is removed before we add new bookings. This means we are not consuming as much memory on client side. Also it means we can now see more clearly what is going on when cars are delivering packages.

<img width="408" alt="image" src="https://user-images.githubusercontent.com/395843/131039898-c5ebf1f1-98c0-41da-a86b-c4384fdc17fa.png">
