### PR TITLE
Feat: kommun info box and timestamp

### DIFF
--- a/packages/visualisation/src/Map.js
+++ b/packages/visualisation/src/Map.js
@@ -9,6 +9,7 @@ import DeckGL, {
 } from 'deck.gl'
 //import { GeoJsonLayer } from '@deck.gl/layers'
 import inside from 'point-in-polygon'
+import { ParagraphLarge } from './components/Typography'
 
 //import CommercialAreas from './data/commercial_areas.json'
 import KommunStatisticsBox from './components/KommunStatisticsBox'
@@ -413,16 +414,6 @@ const Map = ({
     >
       <div
         style={{
-          right: '40px',
-          top: '20px',
-          position: 'absolute',
-          color: 'rgba(255,255,255,0.5)',
-        }}
-      >
-        {new Date(time).toLocaleTimeString()}
-      </div>
-      <div
-        style={{
           bottom: '150px',
           right: '200px',
           position: 'absolute',
@@ -458,7 +449,24 @@ const Map = ({
       />
       {hoverInfo && mapState.zoom > 8 && <HoverInfoBox data={hoverInfo} />}
 
-      {kommunInfo && <KommunStatisticsBox {...kommunInfo} />}
+      {kommunInfo && (
+        <>
+          <div
+            style={{
+              right: '10rem',
+              top: '30px',
+              position: 'absolute',
+            }}
+          >
+            <ParagraphLarge>
+              Just nu är klockan
+              <b> {new Date(time).toLocaleTimeString()} </b> <br />i
+              <b> {kommunInfo.name} </b>
+            </ParagraphLarge>
+          </div>
+          <KommunStatisticsBox {...kommunInfo} />
+        </>
+      )}
     </DeckGL>
   )
 }

--- a/packages/visualisation/src/components/KommunStatisticsBox/index.js
+++ b/packages/visualisation/src/components/KommunStatisticsBox/index.js
@@ -1,64 +1,62 @@
 import React from 'react'
 import styled from 'styled-components'
-import ProgressBar from '../ProgressBar'
-import { Paragraph } from '../Typography'
+import { Paragraph, H4, ParagraphBold } from '../Typography'
 
 const Wrapper = styled.div`
   position: absolute;
-  top: 36px;
-  left: 36px;
+  right: 3rem;
+  top: 6rem;
   display: flex;
   flex-direction: column;
-  justify-content: space-space-between;
-  background-color: #10c57b;
-  padding: 1.7rem;
-  border-radius: 4px;
-  height: 180px;
-  justify-content: space-between;
+  background-color: #f5f5f5;
+  padding: 1.5rem;
+  border-radius: 6px;
   z-index: 1;
-  width: 250px;
 `
 
-const KommunStatisticsBox = ({
-  name,
-  totalCars,
-  totalBookings,
-  totalCapacity,
-  totalCo2,
-  averageDeliveryTime,
-  totalDelivered,
-  averageUtilization,
-  totalCargo,
-  totalQueued,
-  averageQueued,
-}) => {
-  return !totalCars ? null : (
-    <Wrapper>
-      <div>
-        <Paragraph>
-          {totalCars} fordon i {name}
-        </Paragraph>
-        <Paragraph>Total kapacitet: {totalCapacity} kollin</Paragraph>
-        <Paragraph>Antal bokningar: {totalBookings} kollin</Paragraph>
-        <Paragraph>Köat: {totalQueued} kollin</Paragraph>
-        <Paragraph>Lastat: {totalCargo} kollin</Paragraph>
-        {<Paragraph>CO2: {Math.round(totalCo2 * 10) / 10} kg</Paragraph>}
-        <Paragraph>
-          Levererade: {totalDelivered} kollin (
-          {Math.round((totalDelivered / totalBookings) * 100)}%)
-        </Paragraph>
-        <Paragraph>
-          Medel leveranstid: {Math.ceil(10 * averageDeliveryTime) / 10}h
-        </Paragraph>
+const Grid = styled.div`
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: 3fr 2fr;
+`
 
-        {/* <Paragraph>Total cargo: {totalCargo}</Paragraph> */}
-        {/* <Paragraph>Co2: XXX</Paragraph> */}
-        {/* <Paragraph>Antal kollin upphämtade från avlastningscentralen: {bookingsFromHub} st</Paragraph> */}
-      </div>
-      {/* <div> */}
-      <Paragraph thin>Medelfyllnadsgrad per bil:</Paragraph>
-      {<ProgressBar completed={Math.round(averageUtilization * 100)} />}
-      {/* </div> */}
+const GridWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+`
+
+const KommunStatisticsBox = ({ name }) => {
+  return (
+    <Wrapper>
+      <H4>{name}</H4>
+      <GridWrapper>
+        <Grid>
+          <ParagraphBold black>Antal fordon</ParagraphBold>
+          <Paragraph black>xxxx fordon</Paragraph>
+        </Grid>
+        <Grid>
+          <ParagraphBold black>Total kapacitet</ParagraphBold>
+          <Paragraph black>xxxx personer</Paragraph>
+        </Grid>
+        <Grid>
+          <ParagraphBold black>CO2</ParagraphBold>
+          <Paragraph black>xxxx kg</Paragraph>
+        </Grid>
+        <Grid>
+          <ParagraphBold black>Genomsnittskostnad</ParagraphBold>
+          <Paragraph black>xxxx kr/resenär</Paragraph>
+        </Grid>
+        <Grid>
+          <ParagraphBold black>Medelfyllnadsgrad per bil</ParagraphBold>
+          <Paragraph black>xx%</Paragraph>
+        </Grid>
+        <Grid>
+          <ParagraphBold black>Genomsnittlig restid</ParagraphBold>
+          <Paragraph black>xxxx</Paragraph>
+        </Grid>
+      </GridWrapper>
     </Wrapper>
   )
 }

--- a/packages/visualisation/src/components/Typography/index.js
+++ b/packages/visualisation/src/components/Typography/index.js
@@ -3,15 +3,20 @@ import styled from 'styled-components'
 const Paragraph = styled.p`
   margin: 0;
   font-weight: ${(props) => (props.thin ? 300 : 400)};
-  /* font-size: 12pt; */
-  font-size: 14px;
+  font-size: 12px;
   font-family: 'Roboto', sans-serif;
   color: ${(props) => (props.black ? 'black' : 'white')};
 `
 
-const H4 = styled.h4`
-  color: white;
+const ParagraphBold = styled(Paragraph)`
+  font-weight: bold;
+`
+
+const ParagraphLarge = styled.p`
+  font-family: 'Roboto', sans-serif;
+  color: #ffff;
   margin: 0;
+  font-size: 16px;
 `
 
 const H1 = styled.h1`
@@ -29,4 +34,16 @@ const H3 = styled.h3`
   margin: 0;
 `
 
-export { Paragraph, H4, H1, H2, H3 }
+const H4 = styled.h4`
+  color: white;
+  margin: 0;
+  color: black;
+  font-size: 14px;
+`
+
+const H5 = styled.h5`
+  margin: 0;
+  color: black;
+`
+
+export { Paragraph, ParagraphBold, ParagraphLarge, H1, H2, H3, H4, H5 }


### PR DESCRIPTION
<img width="403" alt="Screenshot 2022-06-29 at 15 42 08" src="https://user-images.githubusercontent.com/54809602/176451227-30acc366-65a7-4c2e-82d1-cb4756f0bc37.png">

Updated styling on kommun info box and timestamp 