### PR TITLE
feat: busLines now draws on map

### DIFF
--- a/packages/simulator/index.js
+++ b/packages/simulator/index.js
@@ -27,6 +27,7 @@ const engine = {
       dispatchedBookings: kommuner.pipe(mergeMap((k) => k.dispatchedBookings)),
       buses: regions.pipe(mergeMap((region) => region.buses)),
       busStops: regions.pipe(mergeMap((region) => region.stops)),
+      lineShapes: regions.pipe(mergeMap((region) => region.lineShapes)),
       postombud,
       kommuner,
       parameters,

--- a/packages/simulator/lib/region.js
+++ b/packages/simulator/lib/region.js
@@ -6,13 +6,22 @@ const { taxiDispatch } = require('./taxiDispatch')
 const Taxi = require('./vehicles/taxi')
 
 class Region {
-  constructor({ geometry, name, id, stops, stopTimes, passengers }) {
+  constructor({
+    geometry,
+    name,
+    id,
+    stops,
+    stopTimes,
+    lineShapes,
+    passengers,
+  }) {
     this.geometry = geometry
     this.name = name
     this.id = id
     this.unhandledBookings = new Subject()
     this.stops = stops
     this.passengers = passengers.pipe(shareReplay())
+    this.lineShapes = lineShapes
 
     this.buses = stopTimes.pipe(
       groupBy(({ tripId }) => tripId),

--- a/packages/simulator/streams/gtfs.js
+++ b/packages/simulator/streams/gtfs.js
@@ -57,7 +57,7 @@ const gtfsStream = (file) => {
   return new Observable((observer) => {
     const stream = fs
       .createReadStream(path.join(__dirname, `../data/${operator}/${file}.txt`))
-      .pipe(csv.createStream())
+      .pipe(csv.createStream({ enclosedChar: '"' }))
     stream.on('data', (data) => {
       // console.log(`data ${Object.values(data)}`)
       return observer.next(data)

--- a/packages/simulator/streams/publicTransport.js
+++ b/packages/simulator/streams/publicTransport.js
@@ -11,19 +11,17 @@ const { shareReplay, from, of, firstValueFrom, groupBy, take } = require('rxjs')
 const {
   map,
   mergeMap,
-  switchMap,
-  concatMap,
   filter,
-  toArray,
   first,
-  share,
   tap,
+  reduce,
+  distinct,
+  zip,
+  bufferTime,
 } = require('rxjs/operators')
 const {
   stops,
   busStops,
-  trips,
-  serviceDates,
   tripsMap,
   serviceDatesMap,
   routeNamesMap,
@@ -63,8 +61,62 @@ const enhancedBusStops = busStops.pipe(
   shareReplay()
 )
 
+const stopTimeToDate = (stopTime) => (
+  new Date(`${new Date().toISOString().slice(0, 11)}${stopTime}`)
+)
+
+
+const lineShapes = enhancedBusStops.pipe(
+  map(
+    ({
+      lineNumber,
+      stopName,
+      arrivalTime,
+      tripId,
+      position: { lat, lon },
+    }) => ({
+      lineNumber,
+      arrivalTime,
+      stopName,
+      tripId,
+      stop: {
+        name: stopName,
+        position: [lon, lat],
+      },
+    })
+  ),
+  groupBy((line) => line.tripId, { element: (line) => line }),
+  mergeMap((trip) =>
+    trip.pipe(reduce((acc, cur) => [...acc, cur], [`${trip.key}`]))
+  ),
+  map((arr) => {
+    const values = arr.slice(1).sort((a,b) => (
+      stopTimeToDate(a.arrivalTime) - stopTimeToDate(b.arrivalTime)
+    ))
+    const count = values.length
+    return {
+      lineNumber: arr[1].lineNumber,
+      tripId: arr[0],
+      stops: values.map(({stop}) => (stop.position)),
+      count,
+    }
+  }),
+  groupBy((trip) => trip.lineNumber),
+  mergeMap((lineTrips) =>(
+    lineTrips.pipe(
+      reduce((acc, curr) => {
+        if(acc !== undefined && curr !== undefined && (acc.count === undefined || acc.count < curr.count)) {
+          acc = curr
+        }
+        return acc
+      }, {})
+    )
+  )),
+  map(({ lineNumber, stops }) => ({ lineNumber, stops })),
+)
+
 module.exports = {
   stops,
   stopTimes: enhancedBusStops,
+  lineShapes,
 }
-// enhancedBusStops.subscribe((x) => x)

--- a/packages/simulator/streams/regions/norrbotten.js
+++ b/packages/simulator/streams/regions/norrbotten.js
@@ -1,4 +1,4 @@
-const { stops, stopTimes } = require('../publicTransport')
+const { stops, stopTimes, lineShapes } = require('../publicTransport')
 const { generatePassengers } = require('../../simulator/passengers')
 const Region = require('../../lib/region')
 const { shareReplay } = require('rxjs')
@@ -9,6 +9,7 @@ const norrbotten = new Region({
   stops: stops.pipe(shareReplay()), // todo: support more regions
   stopTimes: stopTimes.pipe(shareReplay()),
   passengers: generatePassengers(),
+  lineShapes: lineShapes.pipe(shareReplay()),
 })
 
 module.exports = norrbotten

--- a/packages/simulator/web/routes.js
+++ b/packages/simulator/web/routes.js
@@ -124,6 +124,9 @@ function register(io) {
     experiment.busStops.subscribe((busStops) =>
       socket.emit('busStops', busStops)
     )
+    experiment.lineShapes.subscribe((lineShapes) =>
+      socket.emit('lineShapes', lineShapes)
+    )
 
     experiment.kommuner
       .pipe(map(({ id, name, geometry }) => ({ id, name, geometry })))

--- a/packages/visualisation/src/App.js
+++ b/packages/visualisation/src/App.js
@@ -27,7 +27,8 @@ const App = () => {
   const [busStopLayer, setBusStopLayer] = useState(true)
   const [passengerLayer, setPassengerLayer] = useState(true)
   const [postombudLayer, setPostombudLayer] = useState(false)
-  const [commercialAreasLayer, setCommercialAreasLayer] = useState(true)
+  const [commercialAreasLayer, setCommercialAreasLayer] = useState(false)
+  const [busLineLayer, setBusLineLayer] = useState(true)
   const [kommunLayer, setKommunLayer] = useState(true)
   const [newParameters, setNewParameters] = useState({})
   const [currentParameters, setCurrentParameters] = useState({})
@@ -51,6 +52,8 @@ const App = () => {
     setCommercialAreasLayer,
     kommunLayer,
     setKommunLayer,
+    setBusLineLayer,
+    busLineLayer,
   }
 
   const newExperiment = (object) => {
@@ -70,6 +73,7 @@ const App = () => {
     setKommuner([])
     setPostombud([])
     setBusStops([])
+    setLineShapes([])
     socket.emit('speed', speed) // reset speed on server
   })
 
@@ -181,6 +185,17 @@ const App = () => {
     ])
   })
 
+  const [lineShapes, setLineShapes] = React.useState([])
+  useSocket('lineShapes', ({ stops, lineNumber }) => {
+    setLineShapes((current) => [
+      ...current,
+      {
+        lineNumber,
+        stops,
+      },
+    ])
+  })
+
   const [kommuner, setKommuner] = React.useState([])
   useSocket('kommun', (kommun) => {
     setKommuner((current) => upsert(current, kommun, 'id'))
@@ -284,6 +299,7 @@ const App = () => {
         activeCar={activeCar}
         time={time}
         setActiveCar={setActiveCar}
+        lineShapes={lineShapes}
       />
     </>
   )

--- a/packages/visualisation/src/Map.js
+++ b/packages/visualisation/src/Map.js
@@ -27,7 +27,7 @@ const commercialAreasLayer = new GeoJsonLayer({
   data: CommercialAreas,
   stroked: true,
   filled: false,
-  extured: false,
+  extruded: false,
   wireframe: false,
   lineJointRounded: true,
   getLineColor: [0, 128, 255],
@@ -43,6 +43,7 @@ const Map = ({
   bookings,
   hubs,
   busStops,
+  lineShapes,
   kommuner,
   activeCar,
   setActiveCar,
@@ -131,6 +132,31 @@ const Map = ({
         y,
       })
     },
+  })
+
+  const geoJsonFromBusLine = (coordinates, lineNumber) => ({
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates,
+    },
+    properties: {
+      name: `bus line ${lineNumber}`,
+    },
+  })
+  const geoJsonFromBusLines = (lineShapes) => {
+    return lineShapes.map(({ stops, lineNumber }) =>
+      geoJsonFromBusLine(stops, lineNumber)
+    )
+  }
+  const busLineLayer = new GeoJsonLayer({
+    id: 'busLineLayer',
+    data: geoJsonFromBusLines(lineShapes),
+    lineWidthScale: 5,
+    lineWidthMinPixels: 2,
+    getFillColor: [240, 10, 30, 120],
+    getLineColor: [240, 10, 30, 120],
+    getLineWidth: 1,
   })
 
   const getColorBasedOnFleet = ({ fleet }) => {
@@ -509,6 +535,7 @@ const Map = ({
         activeLayers.busLayer && busLayer,
         showArcLayer && arcLayer,
         showQueuedBookings && arcLayerQueuedBookings,
+        busLineLayer,
       ]}
     >
       <div

--- a/packages/visualisation/src/components/ExperimentSection/index.js
+++ b/packages/visualisation/src/components/ExperimentSection/index.js
@@ -119,10 +119,16 @@ const ExperimentSection = ({ activeLayers, currentParameters }) => {
       <Container>
         <H3>Fordon</H3>
         <CheckItem
-          text="Buss"
-          setLayer={activeLayers.setCarLayer}
-          checked={activeLayers.carLayer}
+          text="Bussar"
+          setLayer={activeLayers.setBusLayer}
+          checked={activeLayers.busLayer}
           color="#E74493"
+        />
+        <CheckItem
+          text="Busslinjer"
+          setLayer={activeLayers.setBusLineLayer}
+          checked={activeLayers.busLineLayer}
+          color="#F00A1D"
         />
         <div style={{ marginBottom: '0.5rem', marginTop: '2rem' }}>
           <Slider


### PR DESCRIPTION
Now we can draw the buslines on the map! YEAH!

<img width="1708" alt="Screenshot 2022-07-14 at 15 43 06" src="https://user-images.githubusercontent.com/457653/178997698-60923293-dd7d-4456-8d5c-016038fd1358.png">

Upcoming work:

- [ ] [Ask OSRM / VROOM to interpolate the busstops with proper waypoints so that we don't draw the lines as birds-eye routes.](https://trello.com/c/kpWQ3J6I/75-se-till-att-busslinjer-f%C3%B6ljer-v%C3%A4garna-genom-att-skicka-dem-till-osrm-och-f%C3%A5-mer-detaljerade-waypoints-till-linjelagret)

Also fixed a bug where the CSV data was misread:
```
9022025013068001,Sandudden,66.305935,22.896506,0,9021025013068000,A
9022025013070001,"Västra Svartbyn, Nilles",66.257912,22.819135,0,9021025013070000,A
9022025013070002,"Västra Svartbyn, Nilles",66.257948,22.821135,0,9021025013070000,B
```
`Västra Svartbyn, Nilles` was read as: `"Västra Svartbyn`, `Nilles`