### PR TITLE
fix(vroom): switch lon / lat argument to appease vroom

### DIFF
--- a/packages/simulator/lib/taxiDispatch.js
+++ b/packages/simulator/lib/taxiDispatch.js
@@ -23,11 +23,11 @@ const passengerToShipment = (
   amount: [1],
   delivery: {
     id: i,
-    location: [destination.lat, destination.lon],
+    location: [destination.lon, destination.lat],
   },
   pickup: {
     id: i,
-    location: [pickup.lat, pickup.lon],
+    location: [pickup.lon, pickup.lat],
   },
 })
 
@@ -35,7 +35,7 @@ const taxiToVehicle = ({ id, position, capacity, heading }, i) => ({
   id: i,
   description: id,
   capacity: [capacity],
-  start: [position.lat, position.lon],
+  start: [position.lon, position.lat],
   end: heading ? [heading.lat, heading.lon] : undefined,
 })
 

--- a/packages/simulator/lib/vehicles/taxi.js
+++ b/packages/simulator/lib/vehicles/taxi.js
@@ -35,8 +35,8 @@ class Taxi extends Vehicle {
       this.status = 'Pickup'
       this.instruction = instruction
       this.navigateTo({
-        lat: location[0],
-        lon: location[1],
+        lat: location[1],
+        lon: location[0],
       })
     } else {
       this.instructions.push(instruction)
@@ -59,8 +59,8 @@ class Taxi extends Vehicle {
     if (this.instruction) {
       const location = this.instruction.location
       this.navigateTo({
-        lat: location[0],
-        lon: location[1],
+        lat: location[1],
+        lon: location[0],
       })
     }
   }


### PR DESCRIPTION
Vroom expects location argument as [lon, lat] not [lat, lon].
This was handled incorrectly as input in vroom taxiDispatch.js
and handling of the output (result) of vroom in taxi.js