### PR TITLE
fix(generatePassengers): use take instead of bufferTime;

### DIFF
--- a/packages/simulator/simulator/passengers.js
+++ b/packages/simulator/simulator/passengers.js
@@ -1,6 +1,7 @@
 const {
   takeUntil,
   tap,
+  take,
   filter,
   mergeMap,
   mergeAll,
@@ -50,7 +51,9 @@ const generatePassengers = (kommuner) =>
         filter((p) => p !== null)
       )
     ),
-    bufferTime(12000, 2500000)
+
+    take(100),
+    toArray()
   )
 
 const createPassengerFromAddress = ({ position }) =>


### PR DESCRIPTION
to guarantee that atleast 100 passenger are sent to vroom
and the map isnt overflowing with passengers