### PR TITLE
feat: use locally stored MapTiler as maps

### DIFF
--- a/k8s/base/visualisation.yaml
+++ b/k8s/base/visualisation.yaml
@@ -53,14 +53,3 @@ spec:
                 name: visualisation
                 port:
                   number: 80
-
-    - host: rorla-stage.predictivemovement.se
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: visualisation
-                port:
-                  number: 80

--- a/k8s/base/visualisation.yaml
+++ b/k8s/base/visualisation.yaml
@@ -53,3 +53,13 @@ spec:
                 name: visualisation
                 port:
                   number: 80
+    - host: rorla-stage.predictivemovement.se
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: visualisation
+                port:
+                  number: 80

--- a/k8s/base/visualisation.yaml
+++ b/k8s/base/visualisation.yaml
@@ -53,6 +53,7 @@ spec:
                 name: visualisation
                 port:
                   number: 80
+   
     - host: rorla-stage.predictivemovement.se
       http:
         paths:

--- a/k8s/dependencies/tiles/config.yaml
+++ b/k8s/dependencies/tiles/config.yaml
@@ -1,0 +1,57 @@
+---
+# Source: pelias/templates/configmap.tpl
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: maptiler-json-configmap
+  namespace: maptiler
+data:
+  config.json: |
+    {
+      "options": {
+        "paths": {
+          "root": "",
+          "fonts": "fonts",
+          "sprites": "sprites",
+          "styles": "styles",
+          "mbtiles": ""
+        },
+        "domains": [
+          "maptiler.iteam.services",
+          "localhost:8080",
+          "127.0.0.1:8080"
+        ],
+        "formatQuality": {
+          "jpeg": 80,
+          "webp": 90
+        },
+        "maxScaleFactor": 3,
+        "maxSize": 2048,
+        "pbfAlias": "pbf",
+        "serveAllFonts": false,
+        "serveAllStyles": false,
+        "serveStaticMaps": true,
+        "tileMargin": 0
+      },
+      "styles": {
+        "basic": {
+          "style": "basic.json",
+          "tilejson": {
+            "type": "overlay",
+            "bounds": [8.44806, 47.32023, 8.62537, 47.43468]
+          }
+        },
+        "hybrid": {
+          "style": "satellite-hybrid.json",
+          "serve_rendered": false,
+          "tilejson": {
+            "format": "webp"
+          }
+        }
+      },
+      "data": {
+        "sweden-vector": {
+          "mbtiles": "/data/europe_sweden.mbtiles"
+        }
+      }
+    }

--- a/k8s/dependencies/tiles/config.yaml
+++ b/k8s/dependencies/tiles/config.yaml
@@ -18,7 +18,8 @@ data:
         },
         "domains": [
           "maptiler.iteam.services",
-          "localhost:8080",
+          "maptiler.predictivemovement.se",
+          "localhost:3000",
           "127.0.0.1:8080"
         ],
         "formatQuality": {

--- a/k8s/dependencies/tiles/maptiler.yaml
+++ b/k8s/dependencies/tiles/maptiler.yaml
@@ -12,13 +12,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: opentiles
-  namespace: opentiles
+  name: maptiler
+  namespace: maptiler
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: opentiles
+      app: maptiler
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -26,39 +26,30 @@ spec:
   template:
     metadata:
       labels:
-        app: opentiles
-        app-group: opentiles
+        app: maptiler
+        app-group: maptiler
     spec:
       containers:
-        - name: opentiles
-          image: overv/openstreetmap-tile-server
-          args:
-            - "import"
+        - name: maptiler
+          image: maptiler/tileserver-gl
           volumeMounts:
-            - name: opentiles
-              mountPath: /data/database
-          env:
-            - name: DOWNLOAD_PBF
-              value: https://download.geofabrik.de/europe/sweden-latest.osm.pbf
-            - name: DOWNLOAD_POLY
-              value: https://download.geofabrik.de/europe/sweden.poly
-            - name: ALLOW_CORS
-              value: enabled
+            - name: maptiler
+              mountPath: /data
           resources:
             requests:
-              memory: "0.25Gi"
-              cpu: "0.1"
+              memory: "2Gi"
+              cpu: "0.5"
       volumes:
-        - name: opentiles
+        - name: maptiler
           persistentVolumeClaim:
-            claimName: opentiles
+            claimName: maptiler
 
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: opentiles
-  namespace: opentiles
+  name: maptiler
+  namespace: maptiler
 spec:
   accessModes:
     - ReadWriteOnce
@@ -69,11 +60,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: opentiles
-  namespace: opentiles
+  name: maptiler
+  namespace: maptiler
 spec:
   selector:
-    app-group: opentiles
+    app-group: maptiler
   ports:
     - name: http
       protocol: TCP
@@ -83,8 +74,8 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: opentiles-ingress
-  namespace: opentiles
+  name: maptiler-ingress
+  namespace: maptiler
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
@@ -96,14 +87,14 @@ spec:
         - opentiles.predictivemovement.se
       secretName: opentiles-prod-tls
   rules:
-    - host: opentiles.iteam.services
+    - host: maptiler.iteam.services
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: opentiles
+                name: maptiler
                 port:
                   number: 80
     - host: opentiles.predictivemovement.se

--- a/packages/visualisation/package-lock.json
+++ b/packages/visualisation/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "visualisation",
       "version": "0.1.0",
       "dependencies": {
         "@mui/material": "^5.8.7",
@@ -13,7 +12,7 @@
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
         "deck.gl": "^8.5.2",
-        "maplibre-gl": "^1.15.2",
+        "maplibre-gl": "^1.15.3",
         "point-in-polygon": "^1.1.0",
         "rc-slider": "^9.7.2",
         "react": "^17.0.2",
@@ -13299,9 +13298,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.2.tgz",
-      "integrity": "sha512-uPeV530apb4JfX3cRFfE+awFnbcJTOnCv2QvY4mw4huiInbybElWYkNzTs324YLSADq0f4bidRoYcR81ho3aLA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.3.tgz",
+      "integrity": "sha512-ZuOhLCNgp7Yl1L9uyKgZeuo7kKdewP0iWtmEXsZ/snp0JiVkR1Kl+m1rsfKT/wpm/O4zZ7mUGxF16cYbMIFDRA==",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -13317,7 +13316,7 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
@@ -13577,9 +13576,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "3.1.3",
@@ -33087,9 +33086,9 @@
       }
     },
     "maplibre-gl": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.2.tgz",
-      "integrity": "sha512-uPeV530apb4JfX3cRFfE+awFnbcJTOnCv2QvY4mw4huiInbybElWYkNzTs324YLSADq0f4bidRoYcR81ho3aLA==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-1.15.3.tgz",
+      "integrity": "sha512-ZuOhLCNgp7Yl1L9uyKgZeuo7kKdewP0iWtmEXsZ/snp0JiVkR1Kl+m1rsfKT/wpm/O4zZ7mUGxF16cYbMIFDRA==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.5.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -33105,7 +33104,7 @@
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.2.1",
         "grid-index": "^1.1.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
         "potpack": "^1.0.1",
@@ -33322,9 +33321,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "3.1.3",

--- a/packages/visualisation/package.json
+++ b/packages/visualisation/package.json
@@ -8,7 +8,7 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "deck.gl": "^8.5.2",
-    "maplibre-gl": "^1.15.2",
+    "maplibre-gl": "^1.15.3",
     "point-in-polygon": "^1.1.0",
     "rc-slider": "^9.7.2",
     "react": "^17.0.2",

--- a/packages/visualisation/src/Map.js
+++ b/packages/visualisation/src/Map.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { StaticMap } from 'react-map-gl'
+import maplibregl from 'maplibre-gl'
 import DeckGL, {
   PolygonLayer,
   ScatterplotLayer,
@@ -523,7 +524,8 @@ const Map = ({
 
   return (
     <DeckGL
-      mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}
+      mapLib={maplibregl}
+      // mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_ACCESS_TOKEN}
       // initialViewState={mapState.viewport}
       viewState={mapState}
       // onLoad={rotateCamera}
@@ -585,7 +587,9 @@ const Map = ({
       <StaticMap
         reuseMaps
         preventStyleDiffing={true}
-        mapStyle="mapbox://styles/mapbox/dark-v10"
+        mapLib={maplibregl}
+        mapStyle="https://maptiler.iteam.services/styles/basic-preview/style.json"
+        //        mapStyle="https://maptiler.iteam.services/styles/mapbox/dark-v10"
       />
       {hoverInfo && mapState.zoom > 6 && <HoverInfoBox data={hoverInfo} />}
       <TimeProgressBar time={time} />


### PR DESCRIPTION
Use maptiler to serve maps from our cluster. Right now we use the default map style but this can be updated to custom style later.

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/395843/184308060-14af8f7c-f9b0-4850-a397-f605b3b29ddc.png">
