### PR TITLE
feat: generate work addresses based on postombud

### DIFF
--- a/packages/simulator/lib/taxiDispatch.js
+++ b/packages/simulator/lib/taxiDispatch.js
@@ -19,7 +19,6 @@ const journeyToShipment = (id, journey) => ({
 
 const passengersToShipments = (passengers) => {
   const jobMap = {}
-  console.log("passengersToShipments")
   let journeyIndex = 0
   const shipments = [...passengers].flatMap((passenger, passengerIndex) =>
     passenger.journeys.map((journey) => {

--- a/packages/simulator/simulator/passengers.js
+++ b/packages/simulator/simulator/passengers.js
@@ -3,6 +3,7 @@ const {
   tap,
   take,
   filter,
+  map,
   mergeMap,
   mergeAll,
   concatMap,
@@ -19,6 +20,8 @@ const { safeId } = require('../lib/id')
 const Passenger = require('../lib/models/passenger')
 const personNames = require('../lib/personNames')
 const { virtualTime } = require('./../lib/virtualTime')
+const { post } = require('request')
+const { randomize } = require('./address')
 
 const polarbrödÄlvsByn = {
   lat: 65.669641,
@@ -42,31 +45,44 @@ const randomPositions = perlin
 
 const generatePassengers = (kommuner) =>
   kommuner.pipe(
-    mergeMap(({ squares }) =>
-      squares.pipe(
+    mergeMap(({ squares, postombud, name }) => {
+      return squares.pipe(
         mergeMap(({ population, position }) =>
           randomPositions
             .slice(0, population)
             .map(({ x, y }) => addMeters(position, { x, y }))
         ),
-        concatMap((position) =>
-          pelias
-            .nearest(position)
-            .then(createPassengerFromAddress)
-            .catch((_) => null)
-        ),
-        filter((p) => p !== null)
+        mergeMap((homePosition) => {
+          return postombud.pipe(
+            toArray(),
+            map((all_postombud) => {
+              const randomPostombud = all_postombud[Math.floor(Math.random() * all_postombud.length)]
+              return { homePosition, workPosition: randomPostombud.position }
+            })
+          )
+        }),
+        concatMap(async ({ homePosition, workPosition }) => {
+          try {
+            const home = await pelias.nearest(homePosition)
+            const work = await pelias.nearest(workPosition)
+            return { home, work }
+          } catch (e) {
+            return null
+          }
+        }),
+        filter((p) => p),
+        map(createPassengerFromAddress),
       )
-    ),
-
+    }),
     take(100),
     shareReplay(), // ShareReplay needed to keep ID's and names consistent between console and visualisation
     toArray()
   )
-const createPassengerFromAddress = async ({ position }) => {
-  const hemma = { name: 'Hemma', ...position}
-  // Everyone goes to and from work, between 5am and 10am and returns between 3pm and 8pm.
-  // TODO: Also, everyone works at Polarbröd in Älvsbyn
+const createPassengerFromAddress = ({ home, work }) => {
+  console.log("createPassengerFromAddress")
+  const residence = { name: `${home.name}, ${home.localadmin}`, ...home.position}
+  const workplace = { name: `${work.name}, ${work.localadmin}`, ...work.position}
+
   const offset = virtualTime.offset // Sim starts at an offset from midnight, so we need to subctract that offset from the time
   const fiveAm  = (5 * 60 * 60) - offset
   const tenAm   = (10 * 60 * 60) - offset
@@ -76,11 +92,11 @@ const createPassengerFromAddress = async ({ position }) => {
 
   return new Passenger({
     journeys: [
-      { id: safeId(), pickup: hemma, destination: polarbrödÄlvsByn, timeWindow: [[fiveAm, tenAm]], status: 'Väntar' },
-      { id: safeId(), pickup: polarbrödÄlvsByn, destination: hemma, timeWindow: [[threePm, eightPm]], status: 'Väntar' },
+      { id: safeId(), pickup: residence, destination: workplace, timeWindow: [[fiveAm, tenAm]], status: 'Väntar' },
+      { id: safeId(), pickup: workplace, destination: residence, timeWindow: [[threePm, eightPm]], status: 'Väntar' },
     ],
     id: safeId(),
-    position: position,
+    position: home.position,
     name: name,
   })
 }

--- a/packages/simulator/web/routes.js
+++ b/packages/simulator/web/routes.js
@@ -84,7 +84,7 @@ function register(io) {
 
   let emitCars = true
   let emitTaxiUpdates = true
-  let emitBusUpdates = true
+  let emitBusUpdates = false
 
   io.on('connection', function (socket) {
     socket.emit('reset')
@@ -168,7 +168,8 @@ function register(io) {
         io.emit('bookings', bookings)
       }
     })
-  experiment.carUpdates
+
+  const emitOnlyCars = experiment.carUpdates
     .pipe(
       windowTime(100), // start a window every x ms
       mergeMap((win) =>
@@ -177,6 +178,13 @@ function register(io) {
           mergeMap((cars) => cars.pipe(last())) // take the last update in this window
         )
       ),
+      filter((car) => {
+        if (!car) return false
+        if (car.vehicleType === 'bus' && !emitBusUpdates) return false
+        if (car.vehicleType === 'taxi' && !emitTaxiUpdates) return false
+        if (car.vehicleType === 'car' && !emitCars) return false
+        return true
+      }),
       map(cleanCars),
       bufferTime(100, null, 100)
     )


### PR DESCRIPTION
Also, previous PR #101 removed feature that when deselecting layers for cars updates should stop sending, we reintroduced that feature.

Work to be done: 
- [x] Randomize addresses for work slightly, (not everyone works at a postombud!)
- [x] paralellize work and home adress lookup to pelias (`passengers.js L 66-67`)