### PR TITLE
chore: adjust hoverinfobox positioning

### DIFF
--- a/packages/visualisation/src/Map.js
+++ b/packages/visualisation/src/Map.js
@@ -110,13 +110,14 @@ const Map = ({
     getRadius: () => 4,
     getFillColor: [255, 255, 255, 80],
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         type: 'busStop',
         title: 'Busshållplats ' + object.name,
         x,
         y,
+        viewport,
       })
     },
   })
@@ -139,13 +140,14 @@ const Map = ({
   const busLineLayer = new GeoJsonLayer({
     id: 'busLineLayer',
     data: geoJsonFromBusLines(lineShapes),
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         type: 'busLine',
         title: object.properties.name,
         x,
         y,
+        viewport,
       })
     },
     pickable: true,
@@ -184,6 +186,7 @@ const Map = ({
       case 'privat':
         return [34, 166, 179, opacity]
       case 'taxi':
+      case 'anropsstyrd kollektivtrafik':
         return [255, 255, 0, opacity]
       default:
         return [254, 254, 254, opacity]
@@ -217,13 +220,14 @@ const Map = ({
       return c.position
     },
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         ...object,
         type: 'car',
         x,
         y,
+        viewport,
       })
     },
     onClick: ({ object }) => {
@@ -251,13 +255,14 @@ const Map = ({
     //getRadius: (c) => (c.fleet === 'Privat' ? 4 : 8),
     getFillColor: getColorBasedOnFleet,
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         ...object,
         type: 'car',
         x,
         y,
+        viewport
       })
     },
     onClick: ({ object }) => {
@@ -285,13 +290,14 @@ const Map = ({
     //getRadius: (c) => (c.fleet === 'Privat' ? 4 : 8),
     getFillColor: getColorBasedOnFleet,
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         ...object,
         type: 'car',
         x,
         y,
+        viewport,
       })
     },
     onClick: ({ object }) => {
@@ -317,13 +323,14 @@ const Map = ({
     },
     getFillColor: getColorBasedOnFleet,
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         ...object,
         type: 'car',
         x,
         y,
+        viewport,
       })
     },
     onClick: ({ object }) => {
@@ -353,13 +360,14 @@ const Map = ({
       inVehicle ? [0, 0, 0, 0] : [0, 128, 255, 170],
 
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         ...object,
         type: 'passenger',
         x,
         y,
+        viewport,
       })
     },
   })
@@ -384,7 +392,7 @@ const Map = ({
         ? [170, 187, 255, 55]
         : [255, 170, 187, 55],
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       // console.log('booking', object)
       if (!object) return setHoverInfo(null)
       setHoverInfo({
@@ -396,6 +404,7 @@ const Map = ({
           : ' Status: ' + getStatusLabel(object.status),
         x,
         y,
+        viewport,
       })
     },
   })
@@ -416,13 +425,14 @@ const Map = ({
     // #127DBD
     getFillColor: [0, 255, 128, 120],
     pickable: true,
-    onHover: ({ object, x, y }) => {
+    onHover: ({ object, x, y, viewport }) => {
       if (!object) return setHoverInfo(null)
       setHoverInfo({
         type: 'hub',
         title: 'Paketombud för ' + object.operator,
         x,
         y,
+        viewport,
       })
     },
   })

--- a/packages/visualisation/src/components/ExperimentSection/index.js
+++ b/packages/visualisation/src/components/ExperimentSection/index.js
@@ -149,7 +149,7 @@ const ExperimentSection = ({ activeLayers, currentParameters }) => {
           </FlexSpaceBetween>
         </div>
         <CheckItem
-          text="Taxi"
+          text="Anropsstyrd Kollektivtrafik"
           setLayer={activeLayers.setTaxiLayer}
           checked={activeLayers.taxiLayer}
           color="#FBFF33AA"

--- a/packages/visualisation/src/components/HoverInfoBox/index.js
+++ b/packages/visualisation/src/components/HoverInfoBox/index.js
@@ -6,7 +6,7 @@ import { Paragraph } from '../Typography'
 const Wrapper = styled.div`
   position: absolute;
   left: ${(props) => props.left - 50}px;
-  top: ${(props) => props.top - 115}px;
+  bottom: ${(props) => props.top}px;
   background-color: #10c57b;
   min-width: 200px;
   min-height: 60px;
@@ -36,7 +36,7 @@ const CarInfo = ({ data }) => {
       ? 'Passagerare'
       : 'Paket'
   return (
-    <Wrapper left={data.x - 8} top={data.y - 120}>
+    <Wrapper left={data.x} top={data.viewport.height - data.y + 20}>
       <div>
         <Paragraph>{`Fordon ${data.id}`}</Paragraph>
         {data.lineNumber !== undefined && (
@@ -72,7 +72,7 @@ const CarInfo = ({ data }) => {
 
 const PassengerInfo = ({ data }) => {
   return (
-    <Wrapper left={data.x - 25} top={data.y - 65}>
+    <Wrapper left={data.x} top={data.viewport.height - data.y + 20}>
       <Paragraph>Passagerare {data.id}</Paragraph>
       <Paragraph>Namn: {data.name}</Paragraph>
       <Paragraph>Resor:</Paragraph>
@@ -98,7 +98,7 @@ const PassengerInfo = ({ data }) => {
 
 const GenericInfo = ({ data }) => {
   return (
-    <Wrapper left={data.x} top={data.y - 40}>
+    <Wrapper left={data.x} top={data.viewport.height - data.y + 20}>
       <Paragraph>{data.title}</Paragraph>
       <Paragraph>{data.subTitle}</Paragraph>
       {data.deliveryTime ? (

--- a/packages/visualisation/src/components/HoverInfoBox/index.js
+++ b/packages/visualisation/src/components/HoverInfoBox/index.js
@@ -36,7 +36,7 @@ const CarInfo = ({ data }) => {
       ? 'Passagerare'
       : 'Paket'
   return (
-    <Wrapper left={data.x - 8} top={data.y - 80}>
+    <Wrapper left={data.x - 8} top={data.y - 120}>
       <div>
         <Paragraph>{`Fordon ${data.id}`}</Paragraph>
         {data.lineNumber !== undefined && (
@@ -72,7 +72,7 @@ const CarInfo = ({ data }) => {
 
 const PassengerInfo = ({ data }) => {
   return (
-    <Wrapper left={data.x} top={data.y}>
+    <Wrapper left={data.x - 25} top={data.y - 65}>
       <Paragraph>Passagerare {data.id}</Paragraph>
       <Paragraph>Namn: {data.name}</Paragraph>
       <Paragraph>Resor:</Paragraph>


### PR DESCRIPTION
Before this change, hoverinfoboxes covered the dot that it had information about, as a sideeffect, some information in the hoverinfobox was occluded by the mouse pointer.

After this change, all info in the hoverinfoboxes is visible on hover