### PR TITLE
feat: Generate passenger needs

### DIFF
--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -29,6 +29,12 @@ or just once:
 
     npm test
 
+## Generate passenger needs
+
+Run:
+
+    node passengerGenerator.js
+
 ## Concepts
 
 The idea uses two streams of events to simulate a real world scenario:

--- a/packages/simulator/lib/elastic.js
+++ b/packages/simulator/lib/elastic.js
@@ -1,9 +1,10 @@
 const elastic = require('@elastic/elasticsearch')
+
 const mappings = require('../data/elasticsearch_mappings.json')
+const { error, info } = require('./log')
 
 const host = process.env.ELASTICSEARCH_URL || 'http://localhost:9200'
 
-const { error, info } = require('./log')
 
 if (!host) {
   info('No elasticsearch url provided, skipping statistics collection')
@@ -62,13 +63,19 @@ const save = (booking, indexName) => {
       id: booking.id,
       body: booking,
     })
-    .then((_) => info('Saved!'))
+    .then((_) => {})
     .catch((e) => {
       error('Could not save booking', e)
     })
 }
 
+const search = (searchQuery) => {
+  return client
+    .search(searchQuery)
+}
+
 module.exports = {
-  save,
   createIndices,
+  save,
+  search
 }

--- a/packages/simulator/lib/log.js
+++ b/packages/simulator/lib/log.js
@@ -10,8 +10,17 @@ module.exports = {
       console.error(JSON.stringify(data, null, 2))
     }
   },
+  debug: (message, data = '') => {
+    if (LOG_LEVEL !== 'DEBUG') {
+      return
+    }
+    console.log(
+      `${chalk.whiteBright.bold('DEBUG')} ${chalk.white(message)}`,
+      data
+    )
+  },
   info: (message, data = '') => {
-    if (LOG_LEVEL !== 'info') {
+    if (LOG_LEVEL !== 'info' && LOG_LEVEL !== 'DEBUG') {
       return
     }
     console.log(

--- a/packages/simulator/lib/models/passenger.js
+++ b/packages/simulator/lib/models/passenger.js
@@ -28,6 +28,7 @@ class Passenger {
     this.name = name
     this.position = position
     this.startPosition = startPosition
+    this.kommun = kommun
     this.distance = 0
     this.cost = 0
     this.co2 = 0
@@ -167,6 +168,7 @@ class Passenger {
       name: this.name,
       position: this.position,
       waitTime: this.waitTime,
+      kommun: this.kommun,
     }
     return obj
   }

--- a/packages/simulator/lib/pelias.js
+++ b/packages/simulator/lib/pelias.js
@@ -23,19 +23,22 @@ module.exports = {
       .then(
         ({
           features: [
-            { geometry, properties: { name, street, houseNumber, label } } = {},
+            { geometry, properties: { name, street, houseNumber, localadmin, label } } = {},
           ] = [],
         }) => ({
           name,
           street,
           houseNumber,
           label,
+          localadmin,
           position: new Position({
             lon: geometry.coordinates[0],
             lat: geometry.coordinates[1],
           }),
         })
-      )
+      ).catch((e) => {
+        console.error('Error in pelias', e)
+      })
 
     return promise
   },

--- a/packages/simulator/lib/setup.js
+++ b/packages/simulator/lib/setup.js
@@ -1,0 +1,20 @@
+const includedMunicipalities = [
+  'Arjeplog',
+  'Arvidsjaur',
+  'Boden',
+  'Gällivare',
+  'Haparanda',
+  'Jokkmokk',
+  'Kalix',
+  'Kiruna',
+  'Luleå',
+  'Pajala',
+  'Piteå',
+  'Älvsbyn',
+  'Överkalix',
+  'Övertorneå',
+]
+
+module.exports = {
+  includedMunicipalities,
+}

--- a/packages/simulator/lib/virtualTime.js
+++ b/packages/simulator/lib/virtualTime.js
@@ -1,7 +1,7 @@
 const moment = require('moment')
 
 class VirtualTime {
-  constructor(timeMultiplier = 1, startHour = 4) {
+  constructor(timeMultiplier = 1, startHour = 2) {
     this.startHour = startHour
     this.setTimeMultiplier(timeMultiplier)
     this.reset()

--- a/packages/simulator/passengerGenerator.js
+++ b/packages/simulator/passengerGenerator.js
@@ -1,0 +1,154 @@
+const {
+  finalize,
+  take,
+  filter,
+  mergeMap,
+  concatMap,
+  toArray,
+  zipWith
+} = require('rxjs/operators')
+const perlin = require('perlin-noise')
+
+const pelias = require('./lib/pelias')
+const { addMeters } = require('./lib/distance')
+const { randomNames } = require('../lib/personNames')
+const { randomize } = require('./simulator/address')
+const kommuner = require('./streams/kommuner')
+const { save } = require('./lib/elastic')
+const { safeId } = require('./lib/id')
+
+const NUMBER_OF_PASSENGERS = 100
+const GENERATION_ID = safeId()
+const DEBUG = process.env.DEBUG || false
+
+const xy = (i, size = 100) => ({ x: i % size, y: Math.floor(i / size) })
+
+const execute = () => {
+  console.log(
+    `Generating and saving ${NUMBER_OF_PASSENGERS} passengers to elasticSearch as group ${GENERATION_ID}`
+  )
+  generatePassengerDetails(kommuner, NUMBER_OF_PASSENGERS).subscribe(
+    passengerSerializer,
+    console.error,
+    finalLogger
+  )
+}
+
+const finalLogger = () => {
+  save(
+    { needs: 'to_and_from_work', size: 50, GENERATION_ID },
+      'passenger_generation'
+    )
+  console.log(
+    `\n\nGenerated and saved ${NUMBER_OF_PASSENGERS} passengers to elasticSearch as group ${GENERATION_ID}`
+  )
+}
+
+// generate a pattern of random positions so we can take x out of these and get a natural pattern of these positions
+const randomPositions = perlin
+  .generatePerlinNoise(100, 100)
+  .map((probability, i) => ({
+    x: xy(i).x * 10,
+    y: xy(i).y * 10,
+    probability,
+  }))
+  .sort((a, b) => b.probability - a.probability) // sort them so we can just pick how many we want
+
+const generatePassengerDetails = (kommuner, numberOfPassengers) =>
+  kommuner.pipe(
+    mergeMap(({ squares, postombud, name }) => {
+      if(DEBUG) process.stdout.write('🌆')
+      return squares.pipe(
+        mergeMap(({ population, position }) => {
+          if(DEBUG) process.stdout.write(' 🗺 ')
+          return randomPositions
+            .slice(0, population)
+            .map(({ x, y }) => addMeters(position, { x, y }))
+        }),
+        mergeMap((homePosition) => {
+          if(DEBUG) process.stdout.write('📍')
+          return postombud.pipe(
+            toArray(),
+            mergeMap(async (allPostombudInKommun) => {
+              const randomPostombud =
+                allPostombudInKommun[Math.floor(Math.random() * allPostombudInKommun.length)]
+              try {
+                const workPosition = await randomize(randomPostombud.position)
+                return { homePosition, workPosition }
+              } catch (err) {
+                console.warn('timeout randomizing work position', err)
+                return null
+              }
+            }, 20)
+          )
+        }, 20),
+        filter((p) => p),
+        concatMap(async ({ homePosition, workPosition }) => {
+          if(DEBUG) process.stdout.write('🏠')
+          try {
+            const home = await pelias.nearest(homePosition)
+            return { home, workPosition }
+          } catch (e) {
+            console.warn('timeout finding nearest address to home position', err)
+            return null
+          }
+        }),
+        filter((p) => p),
+        concatMap(async ({ home, workPosition }) => {
+          if(DEBUG) process.stdout.write('🏢')
+          try {
+            const work = await pelias.nearest(workPosition)
+            return { home, work }
+          } catch (e) {
+            console.warn('timeout finding nearest address to work position', err)
+            return null
+          }
+        }),
+        filter((p) => p),
+        zipWith(
+          randomNames.pipe(take(Math.min(100, Math.ceil(kommun.population * 0.01))))
+        ), // for some reason we need to limit the randomNames stream here, otherwise it will never end
+        concatMap(async ({ home, work }, {name, firstName, lastName}) => {
+          if(DEBUG) process.stdout.write('📦')
+          return Promise.resolve({
+            position: home.position,
+            // home,
+            // work,
+            home: {
+              name: `${home.name}, ${home.localadmin}`,
+              ...home.position,
+            },
+            workplace: {
+              name: `${work.name}, ${work.localadmin}`,
+              ...work.position,
+            },
+            kommun,
+            name,
+            firstName,
+            lastName,
+          })
+        })
+      )
+    }),
+    take(numberOfPassengers),
+    finalize()
+  )
+const passengerSerializer = ({ name, firstName, lastName, home, workplace, kommun }) => {
+  const saveablePassenger = {
+    id: safeId(),
+    name,
+    firstName,
+    lastName,
+    home,
+    workplace,
+    kommun,
+    source: 'generated',
+    generationGroupSize: NUMBER_OF_PASSENGERS,
+    generationId: GENERATION_ID,
+  }
+  save(saveablePassenger, 'passenger_needs')
+  process.stdout.write('💾')
+}
+
+execute()
+

--- a/packages/simulator/simulator/passengers.js
+++ b/packages/simulator/simulator/passengers.js
@@ -48,7 +48,6 @@ const passengersFromNeeds = (kommunName, numberOfPassengers = 250) => {
     }, 4),
     map(createPassengerFromAddress),
     take(numberOfPassengers),
-    toArray()
   )
 }
 

--- a/packages/simulator/simulator/passengers.js
+++ b/packages/simulator/simulator/passengers.js
@@ -1,89 +1,60 @@
 const {
   take,
-  filter,
   map,
   mergeMap,
-  concatMap,
   toArray,
-  shareReplay,
-  zipWith,
 } = require('rxjs/operators')
-const perlin = require('perlin-noise')
 
-const pelias = require('../lib/pelias')
-const { addMeters } = require('../lib/distance')
 const Passenger = require('../lib/models/passenger')
-const { randomNames } = require('../lib/personNames')
-const { randomize } = require('./address')
 
-const xy = (i, size = 100) => ({ x: i % size, y: Math.floor(i / size) })
+const elastic = require('./../lib/elastic')
+const { from } = require('rxjs')
 
-// generate a pattern of random positions so we can take x out of these and get a natural pattern of these positions
-const randomPositions = perlin
-  .generatePerlinNoise(100, 100)
-  .map((probability, i) => ({
-    x: xy(i).x * 10,
-    y: xy(i).y * 10,
-    probability,
-  }))
-  .sort((a, b) => b.probability - a.probability) // sort them so we can just pick how many we want
+const findPassengerNeeds = (limit) => {
+  return elastic.search({
+    index: 'passenger_needs',
+    body: {
+      query: {
+        bool: {
+          must: [
+            {
+              match: {
+                source: 'generated',
+              },
+            },
+          ],
+        },
+      },
+      size: limit,
+    },
+  })
+}
 
-const generatePassengers = (kommun) =>
-  kommun.squares.pipe(
-    mergeMap(({ population, position }) =>
-      randomPositions
-        .slice(0, population)
-        .map(({ x, y }) => addMeters(position, { x, y }))
-    ),
-    mergeMap((homePosition) => {
-      return kommun.postombud.pipe(
-        toArray(),
-        mergeMap(async (postombudInKommun) => {
-          const randomPostombud =
-            postombudInKommun[
-              Math.floor(Math.random() * postombudInKommun.length)
-            ]
-          const workPosition = await randomize(randomPostombud.position)
-          return { homePosition, workPosition }
-        })
-      )
-    }, 20),
-    concatMap(async ({ homePosition, workPosition }) => {
-      try {
-        const home = await pelias.nearest(homePosition, 'address')
-        return { home, workPosition }
-      } catch (e) {
-        return null
-      }
-    }),
-    filter((p) => p),
-    concatMap(async ({ home, workPosition }) => {
-      try {
-        const workplace = await pelias.nearest(workPosition)
-        return { home, workplace }
-      } catch (e) {
-        return null
-      }
-    }),
-    filter((p) => p),
-    zipWith(
-      randomNames.pipe(take(Math.min(100, Math.ceil(kommun.population * 0.01))))
-    ), // for some reason we need to limit the randomNames stream here, otherwise it will never end
-    map(
-      ([{ home, workplace }, { name, firstName, lastName }]) =>
-        new Passenger({
-          position: home.position,
-          workplace,
-          kommun,
-          home,
-          name,
-          firstName,
-          lastName,
-        })
-    )
-    //    take() // sample 1% of the population
+const passengersFromNeeds = (numberOfPassengers = 250) => {
+  if (numberOfPassengers > 250) { numberOfPassengers = 250 }
+  return from(findPassengerNeeds(numberOfPassengers)).pipe(
+    mergeMap((results) => {
+      return results.body.hits.hits
+    },4),
+    map(createPassengerFromAddress),
+    take(numberOfPassengers),
+    toArray(),
   )
+}
+
+const createPassengerFromAddress = (hit) => {
+  const { name, home, workplace, kommun, id } = hit._source
+  return new Passenger({
+    id,
+    home,
+    workplace,
+    kommun,
+    position: { lat: home.lat, lon: home.lon },
+    startPosition: { lat: home.lat, lon: home.lon },
+    name: name,
+  })
+}
 
 module.exports = {
-  generatePassengers,
+  passengersFromNeeds,
 }

--- a/packages/simulator/streams/kommuner.js
+++ b/packages/simulator/streams/kommuner.js
@@ -4,9 +4,6 @@
 const {
   from,
   shareReplay,
-  withLatestFrom,
-  merge,
-  range,
   ReplaySubject,
 } = require('rxjs')
 const {
@@ -14,10 +11,7 @@ const {
   tap,
   filter,
   reduce,
-  finalize,
-  share,
   mergeMap,
-  count,
 } = require('rxjs/operators')
 const Kommun = require('../lib/kommun')
 const data = require('../data/kommuner.json')
@@ -26,10 +20,8 @@ const packageVolumes = require('./packageVolumes')
 const postombud = require('./postombud')
 const inside = require('point-in-polygon')
 const commercialAreas = from(require('../data/scb_companyAreas.json').features)
-const { generateBookingsInKommun } = require('../simulator/bookings')
-const bookingsCache = require('../streams/cacheBookingStream')
 const Pelias = require('../lib/pelias')
-const { generatePassengers } = require('../simulator/passengers')
+const { passengersFromNeeds } = require('../simulator/passengers')
 
 function getPopulationSquares({ geometry: { coordinates } }) {
   return population.pipe(
@@ -110,8 +102,7 @@ function read() {
       }
     ),
     tap((kommun) => {
-      //kommun.bookings = generateBookingsInKommun(kommun)
-      generatePassengers(kommun).subscribe((passenger) =>
+      passengersFromNeeds(kommun).subscribe((passenger) =>
         kommun.citizens.next(passenger)
       )
     }),

--- a/packages/simulator/streams/kommuner.js
+++ b/packages/simulator/streams/kommuner.js
@@ -22,6 +22,8 @@ const inside = require('point-in-polygon')
 const commercialAreas = from(require('../data/scb_companyAreas.json').features)
 const Pelias = require('../lib/pelias')
 const { passengersFromNeeds } = require('../simulator/passengers')
+const { includedMunicipalities } = require('../lib/setup')
+
 
 function getPopulationSquares({ geometry: { coordinates } }) {
   return population.pipe(
@@ -50,22 +52,7 @@ function getPostombud(kommunName) {
 function read() {
   return from(data).pipe(
     filter(({ namn }) =>
-      [
-        'Arjeplog',
-        'Arvidsjaur',
-        'Boden',
-        'Gällivare',
-        'Haparanda',
-        'Jokkmokk',
-        'Kalix',
-        'Kiruna',
-        'Luleå',
-        'Pajala',
-        'Piteå',
-        'Älvsbyn',
-        'Överkalix',
-        'Övertorneå',
-      ].some((name) => namn.startsWith(name))
+      includedMunicipalities.some((name) => namn.startsWith(name))
     ),
     mergeMap(
       async ({
@@ -102,7 +89,7 @@ function read() {
       }
     ),
     tap((kommun) => {
-      passengersFromNeeds(kommun).subscribe((passenger) =>
+      passengersFromNeeds(kommun.name).subscribe((passenger) =>
         kommun.citizens.next(passenger)
       )
     }),

--- a/packages/simulator/streams/kommuner.js
+++ b/packages/simulator/streams/kommuner.js
@@ -89,9 +89,7 @@ function read() {
       }
     ),
     tap((kommun) => {
-      passengersFromNeeds(kommun.name).subscribe((passenger) =>
-        kommun.citizens.next(passenger)
-      )
+      passengersFromNeeds(kommun.name).subscribe((passenger) => kommun.citizens.next(passenger))
     }),
 
     shareReplay()

--- a/packages/simulator/streams/regions/norrbotten.js
+++ b/packages/simulator/streams/regions/norrbotten.js
@@ -1,5 +1,5 @@
 const { stops, stopTimes, lineShapes } = require('../publicTransport')
-const { generatePassengers } = require('../../simulator/passengers')
+const { passengersFromNeeds } = require('../../simulator/passengers')
 const Region = require('../../lib/region')
 const { shareReplay, mergeMap } = require('rxjs')
 


### PR DESCRIPTION
Idea for future work, let an endpoint take a numeric argument of how many passengers to create and invoke `passengerGenerator` and return the groupId. Not sure how easy it is to run the generation script in kubernetes in production.