### PR TITLE
fix: menu buttons in safari

### DIFF
--- a/packages/visualisation/src/components/SideMenu/index.js
+++ b/packages/visualisation/src/components/SideMenu/index.js
@@ -48,6 +48,10 @@ const MenuItem = styled.li`
   display: flex;
   align-items: center;
   z-index: 4;
+
+  img {
+    width: 32px;
+  }
 `
 
 const ActiveMenu = styled.div`


### PR DESCRIPTION
I gave the menu symbols a fixed with so the +-sign is no longer huge in Safari. 

Tested on Firefox and Safari, desktop + mobile.